### PR TITLE
Set build type of gbenchmark as 'Release'.

### DIFF
--- a/conf/googlebenchmark.mk
+++ b/conf/googlebenchmark.mk
@@ -22,7 +22,7 @@ override GOOGLE_BENCHMARK_MK := T
 # ==============
 GIT_DEPENDENCY  += \
     gbenchmark => https://github.com/google/benchmark.git \
-                  mkdir -p build && cd build && cmake .. && make
+                  mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make
 
 # Paths
 # =======


### PR DESCRIPTION
It should fix the following warning:

'***WARNING*** Library was built as DEBUG. Timings may be affected'